### PR TITLE
Add support for rebooting into picoboot3 from inside the program

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,16 @@ Connect the device as follows:
 | UART RX | ---  | UART TX (Default is GP0)  |
 | GND     | ---  | GND           |
 
-Reset the MCU by holding BOOTSEL3 pin (default is GP22) low to enter bootloader mode. 
+Reboot into picoboot3 by either
+- restarting the MCU and holding BOOTSEL3 pin (default is GP22) low
+- using the following code:
+  ```C++
+  watchdog_hw->scratch[0] = 1;
+  watchdog_reboot(0, 0, 10);
+  while (1) {
+    continue;
+  }
+  ```
 
 Write firmware with the following command. 
 Only bin format is supported. Do not use elf or uf2. 

--- a/src/picoboot3.c
+++ b/src/picoboot3.c
@@ -15,6 +15,7 @@
 #include "hardware/spi.h"
 #include "hardware/sync.h"
 #include "hardware/uart.h"
+#include "hardware/watchdog.h"
 #include "picoboot3.h"
 
 #define RECEIVE_BUFFER_SIZE 4200
@@ -122,6 +123,10 @@ void picoboot3_bootsel_deinit() {
 }
 
 bool picoboot3_bootsel_is_bootloader() {
+  if (watchdog_hw->scratch[0]) {
+    watchdog_hw->scratch[0] = 0 ;
+    return true;
+  }
   if (PICOBOOT3_BOOTSEL3_VAL_TO_START_BOOTLOADER == gpio_get(PICOBOOT3_BOOTSEL3_PIN)) {
     return true;
   }


### PR DESCRIPTION
The bootloader now first checks if the first watchdog scratch register is set to 1 and if it is it will boot into the bootloader regardless of th BOOTSEL3_PIN state.
The watchdog scratch register code is taken from the Hunter Adams bootloader example [here](https://github.com/vha3/Hunter-Adams-RP2040-Demos/blob/ca09098abe290305022ef7a28d04c1adb09e8544/Bootloaders/Serial_bootloader/Bootloader/bootloader.c#L459) and [here](https://github.com/vha3/Hunter-Adams-RP2040-Demos/blob/ca09098abe290305022ef7a28d04c1adb09e8544/Bootloaders/Serial_bootloader/Application/bootloader_blinky.c#L16) and the reboot code is taken from the arduino-pico code [here](https://github.com/earlephilhower/arduino-pico/blob/e05dd50d626d2871ab988d8e72aa7c12e18e603c/cores/rp2040/RP2040Support.h#L457)